### PR TITLE
ライセンス修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,11 @@ EPUB(publish.epub)を作成する。
   * `rmrf` ... ファイル削除。`RUN find #{head} -iname #{name1} -o -iname #{name2} ... | grep -v /proc/ | xargs rm -rf` を実行
 * `template/make.sh`を使うと思う
   * `make build` (= `make`) したなら、`env CONTAINER_VERSION="debug" ./make.sh build --help`で実行できる
+* テストは簡易でいい
+  * `env CONTAINER_VERSION="debug" ./make.sh build --proof --pdf4print --pdf4publish --epub --strict --verbose` な感じ
+  * ぱっと見でエラーが出ていない、かつ出力が想定どおりならOKでいい
+  * それで問題があったら自動テストを用意する
+
 
 ## Contribution
 * fork して pull request してもらえたらと思います。
@@ -74,13 +79,20 @@ EPUB(publish.epub)を作成する。
 ```
 Copyright (c) 2017-2018 SIGCOWW.
 ```
+ただし、 `templete/` ディレクトリ以下は、別のライセンスが適用されています。
 
-本ソフトウェアのリポジトリには、下記ソフトウェアの一部または全部が含まれます。
+また、本ソフトウェアのリポジトリには、下記ソフトウェアの一部または全部が含まれます。
 
 ### [Re:VIEW](https://github.com/kmuto/review)
 GNU Lesser General Public License v2.1 ([COPYING](https://github.com/kmuto/review/blob/master/COPYING))
 ```
 Copyright (c) 2006-2018 Minero Aoki, Kenshi Muto, Masayoshi Takahashi, Masanori Kado.
+```
+
+### [template files for Re:VIEW](https://github.com/kmuto/review/tree/master/templates)
+The MIT License ([LICENSE](https://github.com/kmuto/review/blob/master/templates/LICENSE))
+```
+Copyright (c) 2006-2016 Minero Aoki, Kenshi Muto, Masayoshi Takahashi, Masanori Kado.
 ```
 
 ### [jumoline.sty](http://www.para.media.kyoto-u.ac.jp/latex/)

--- a/template/README.md
+++ b/template/README.md
@@ -73,3 +73,37 @@ src/
 
 ### 文字コードはUTF-8
 * そもそも、それ以外だとGitHubで見たときに文字化けしそうな気もする
+
+
+## ライセンス
+本ディレクトリ以下は、[Beerwareライセンス](https://en.wikipedia.org/wiki/Beerware)のもとで提供されます。
+```
+/*
+* ----------------------------------------------------------------------------
+* "THE BEER-WARE LICENSE" (Revision 42):
+* sigcoww@sigcoww.org wrote this file. As long as you retain this notice you
+* can do whatever you want with this stuff. If we meet some day, and you think
+* this stuff is worth it, you can buy me a beer in return <author>
+* ----------------------------------------------------------------------------
+*/
+```
+
+本ディレクトリ以下には、下記ソフトウェアの一部が含まれます。
+
+### [template files for Re:VIEW](https://github.com/kmuto/review/tree/master/templates)
+The MIT License ([LICENSE](https://github.com/kmuto/review/blob/master/templates/LICENSE))
+```
+Copyright (c) 2006-2016 Minero Aoki, Kenshi Muto, Masayoshi Takahashi, Masanori Kado.
+```
+
+### [ReVIEW-Template](https://github.com/TechBooster/ReVIEW-Template)
+The MIT License
+```
+Copyright 2017 TechBooster
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+```

--- a/template/README.md
+++ b/template/README.md
@@ -83,7 +83,7 @@ src/
 * "THE BEER-WARE LICENSE" (Revision 42):
 * sigcoww@sigcoww.org wrote this file. As long as you retain this notice you
 * can do whatever you want with this stuff. If we meet some day, and you think
-* this stuff is worth it, you can buy me a beer in return <author>
+* this stuff is worth it, you can buy me a beer in return            SIGCOWW
 * ----------------------------------------------------------------------------
 */
 ```


### PR DESCRIPTION
# 概要
`templete/` 以下について、LGPLのコピーレフト適用外であることが判明した。
であれば、ソースコード開示の義務のない緩いライセンスにすべく、Beerwareライセンスを適用することにした。