### PR TITLE
publish.pdf と publish-tmp.pdf を整理

### DIFF
--- a/docker/build.rb
+++ b/docker/build.rb
@@ -140,7 +140,7 @@ EOF
     dummy_image('back.png', 'BACK')
     defcolor = `colorpicker.js cover.png`
 
-    File.write('publish-tmp.tex', <<eof
+    File.write('publish-raw.tex', <<eof
 \\documentclass[uplatex,dvipdfmx,#{@papersize}paper,oneside]{jsbook}
 \\usepackage{pdfpages}
 \\pagestyle{empty}
@@ -162,9 +162,9 @@ EOF
 \\end{document}
 eof
 )
-    run("uplatex publish-tmp")
-    run("dvipdfmx publish-tmp")
-    run("gs -sOutputFile=publish.pdf -sDEVICE=pdfwrite -dNOPAUSE -dBATCH -q -dPDFSETTINGS=/ebook -dDownsampleColorImages=true -dColorImageResolution=300 publish-tmp.pdf")
+    run("uplatex publish-raw")
+    run("dvipdfmx publish-raw")
+    run("gs -sOutputFile=publish-ebook.pdf -sDEVICE=pdfwrite -dNOPAUSE -dBATCH -q -dPDFSETTINGS=/ebook -dDownsampleColorImages=true -dColorImageResolution=300 publish-raw.pdf")
   end
 
   def epub()
@@ -179,7 +179,7 @@ eof
   def clean()
     header("Cleaning")
     unless @is_verbose
-      artifacts = ['original.pdf', 'honbun.pdf', 'publish-tmp.pdf', 'publish.pdf', 'publish.epub', 'book-text']
+      artifacts = ['original.pdf', 'honbun.pdf', 'publish-raw.pdf', 'publish-ebook.pdf', 'publish.epub', 'book-text']
       Dir.glob('*').each do | file |
         next if artifacts.include?(file)
         FileUtils.rm_rf(file)

--- a/template/.circleci/config.yml
+++ b/template/.circleci/config.yml
@@ -15,7 +15,9 @@ jobs:
       - store_artifacts:
           path: /work/src/working_temporary_directory/honbun.pdf
       - store_artifacts:
-          path: /work/src/working_temporary_directory/publish-tmp.pdf
+          path: /work/src/working_temporary_directory/publish-raw.pdf
+      - store_artifacts:
+          path: /work/src/working_temporary_directory/publish-ebook.pdf
       - store_artifacts:
           path: /work/src/working_temporary_directory/publish.epub
       - store_artifacts:

--- a/template/README.md
+++ b/template/README.md
@@ -42,7 +42,8 @@ src/
 └─ working_temporary_directory/ ..... 成果物ディレクトリ(Git管理外)
      ├─ origin.pdf ..... Re:VIEWによる出力
      ├─ honbun.pdf ..... 入稿用PDF
-     ├─ publish.pdf .... 電子書籍PDF
+     ├─ publish-row.pdf .... 電子書籍PDF（Re:VIEW出力そのまま）
+     ├─ publish-ebook.pdf .... 電子書籍PDF（publish-raw.pdfをghostscriptで最適化…のはずだがテキスト選択に難がある）
      └─ publish.epub ... 電子書籍EPUB
 ```
 これを作るのは`tree`コマンドが便利。


### PR DESCRIPTION
# 概要
#11 のように、publish.pdf と publish-tmp.pdf が分かりにくい。

# 変更内容
それぞれ、 publish-ebook.pdf と publish-raw.pdf に変更した。